### PR TITLE
Add Dependabot Version Patch workflow

### DIFF
--- a/.github/workflows/dependabot-version-patch.yml
+++ b/.github/workflows/dependabot-version-patch.yml
@@ -1,0 +1,43 @@
+name: Dependabot Version Patch
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  npm-version-patch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.labels.*.name == 'approved' && contains(github.event.pull_request.labels.*.name, 'dependabot')
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed_files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'  # Adjust the version as per your project requirements
+
+      - name: Install dependencies and patch version
+        if: steps.changed_files.outputs.all_modified_files != ''
+        run: |
+          CHANGED_DIR=$(dirname $(echo "${{ steps.changed_files.outputs.all_modified_files }}" | tr ' ' '\n' | uniq))
+          cd $CHANGED_DIR
+          npm ci
+          npm version patch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Changes
+        if: steps.changed_files.outputs.all_modified_files != ''
+        uses: ad-m/github-push-action@v0.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
This pull request adds a Dependabot Version Patch workflow that automatically updates the patch version of the project's dependencies when a pull request with the label "approved" and containing "dependabot" is created. This ensures that the project's dependencies are always up to date with the latest patches.